### PR TITLE
Added check for gnupg package, install if it is missing

### DIFF
--- a/minione
+++ b/minione
@@ -667,10 +667,10 @@ fi
 
 # check if gnupg is installed (required for apt-key add)
 if debian?; then
-	check "dpkg -L gnupg >/dev/null 2>&1" \
-		"Checking if gnupg is installed" \
-		"SKIP will try to install" || \
-		MISSING_PKGS="${MISSING_PKGS} gnupg"
+    check "dpkg -L gnupg >/dev/null 2>&1" \
+        "Checking if gnupg is installed" \
+        "SKIP will try to install" || \
+        MISSING_PKGS="${MISSING_PKGS} gnupg"
 fi
 
 # check if we have iptables-persistent netfilter-persistent

--- a/minione
+++ b/minione
@@ -665,6 +665,14 @@ if debian?; then
         MISSING_PKGS="${MISSING_PKGS} apt-transport-https"
 fi
 
+# check if gnupg is installed (required for apt-key add)
+if debian?; then
+	check "dpkg -L gnupg >/dev/null 2>&1" \
+		"Checking if gnupg is installed" \
+		"SKIP will try to install" || \
+		MISSING_PKGS="${MISSING_PKGS} gnupg"
+fi
+
 # check if we have iptables-persistent netfilter-persistent
 if debian?; then
     check "dpkg -l iptables-persistent netfilter-persistent > /dev/null" \


### PR DESCRIPTION
On some Debian-based distro's, the gnupg package does not come as a default package. However, this package is needed for the `apt-key` utility when you want to import a key into the keyring. The `minione` installation might fail because of this.