### PR TITLE
Add /etc/apt/keyrings if not exist 

### DIFF
--- a/minione
+++ b/minione
@@ -731,7 +731,7 @@ EOF
 start_dnsmasq() {
     if [[ $1 = 'purge' ]]; then
         if [[ -f /etc/dnsmasq.conf.bk ]]; then
-            mv /etc/dnsmasq.conf.bk /etc/dnsmasq.c>
+            mv /etc/dnsmasq.conf.bk /etc/dnsmasq.conf>
         else
             rm -f /etc/dnsmasq.conf
             systemctl stop dnsmasq

--- a/minione
+++ b/minione
@@ -734,7 +734,37 @@ start_dnsmasq() {
             mv /etc/dnsmasq.conf.bk /etc/dnsmasq.conf
         else
             rm -f /etc/dnsmasq.conf
-            systemctl stop dnsmasq
+            systemctl stop dnsmasqconfigure_repos() {
+    if centos; then
+        if [[ $1 = 'purge' ]]; then
+            rm -f /etc/yum.repos.d/opennebula.repo
+        else
+            cat <<EOT >/etc/yum.repos.d/opennebula.repo
+[opennebula]
+name=opennebula
+baseurl=${REPO_BASE}/${DISTNAME}/${DISTVER}/x86_64
+enabled=1
+gpgkey=https://downloads.opennebula.io/repo/${REPO_KEY}
+gpgcheck=1
+EOT
+        fi
+    elif debian; then
+        if [[ $1 = 'purge' ]]; then
+            rm -f /etc/apt/sources.list.d/opennebula.list
+        else
+            # Check if /etc/apt/keyrings directory exists, if not, create it
+            if [ ! -d /etc/apt/keyrings ]; then
+                install -m 0755 -d /etc/apt/keyrings
+            fi
+
+            (wget -q -O- https://downloads.opennebula.io/repo/"${REPO_KEY}" |
+                gpg --dearmor --yes --output /etc/apt/keyrings/opennebula.gpg) || return 1
+            echo "deb [signed-by=/etc/apt/keyrings/opennebula.gpg] ${REPO_BASE}/${DISTNAME}/${DISTVER} >
+                >/etc/apt/sources.list.d/opennebula.list || return 1
+        fi
+    fi
+}
+
         fi
     else
         cp /etc/dnsmasq.conf /etc/dnsmasq.conf.bk 2>/dev/null

--- a/minione
+++ b/minione
@@ -731,13 +731,13 @@ EOF
 start_dnsmasq() {
     if [[ $1 = 'purge' ]]; then
         if [[ -f /etc/dnsmasq.conf.bk ]]; then
-            mv /etc/dnsmasq.conf.bk /etc/dnsmasq.conf>
+            mv /etc/dnsmasq.conf.bk /etc/dnsmasq.conf
         else
             rm -f /etc/dnsmasq.conf
             systemctl stop dnsmasq
         fi
     else
-        cp /etc/dnsmasq.conf /etc/dnsmasq.conf.bk >
+        cp /etc/dnsmasq.conf /etc/dnsmasq.conf.bk 2>/dev/null
         cat <<EOT >/etc/dnsmasq.conf || return 1
 interface=${BRIDGE_INTERFACE},lo
 bind-interfaces

--- a/minione
+++ b/minione
@@ -731,43 +731,13 @@ EOF
 start_dnsmasq() {
     if [[ $1 = 'purge' ]]; then
         if [[ -f /etc/dnsmasq.conf.bk ]]; then
-            mv /etc/dnsmasq.conf.bk /etc/dnsmasq.conf
+            mv /etc/dnsmasq.conf.bk /etc/dnsmasq.c>
         else
             rm -f /etc/dnsmasq.conf
-            systemctl stop dnsmasqconfigure_repos() {
-    if centos; then
-        if [[ $1 = 'purge' ]]; then
-            rm -f /etc/yum.repos.d/opennebula.repo
-        else
-            cat <<EOT >/etc/yum.repos.d/opennebula.repo
-[opennebula]
-name=opennebula
-baseurl=${REPO_BASE}/${DISTNAME}/${DISTVER}/x86_64
-enabled=1
-gpgkey=https://downloads.opennebula.io/repo/${REPO_KEY}
-gpgcheck=1
-EOT
-        fi
-    elif debian; then
-        if [[ $1 = 'purge' ]]; then
-            rm -f /etc/apt/sources.list.d/opennebula.list
-        else
-            # Check if /etc/apt/keyrings directory exists, if not, create it
-            if [ ! -d /etc/apt/keyrings ]; then
-                install -m 0755 -d /etc/apt/keyrings
-            fi
-
-            (wget -q -O- https://downloads.opennebula.io/repo/"${REPO_KEY}" |
-                gpg --dearmor --yes --output /etc/apt/keyrings/opennebula.gpg) || return 1
-            echo "deb [signed-by=/etc/apt/keyrings/opennebula.gpg] ${REPO_BASE}/${DISTNAME}/${DISTVER} >
-                >/etc/apt/sources.list.d/opennebula.list || return 1
-        fi
-    fi
-}
-
+            systemctl stop dnsmasq
         fi
     else
-        cp /etc/dnsmasq.conf /etc/dnsmasq.conf.bk 2>/dev/null
+        cp /etc/dnsmasq.conf /etc/dnsmasq.conf.bk >
         cat <<EOT >/etc/dnsmasq.conf || return 1
 interface=${BRIDGE_INTERFACE},lo
 bind-interfaces
@@ -795,6 +765,11 @@ EOT
         if [[ $1 = 'purge' ]]; then
             rm -f /etc/apt/sources.list.d/opennebula.list
         else
+	    # Check if /etc/apt/keyrings directory exists, if not, create it
+            if [ ! -d /etc/apt/keyrings ]; then
+                install -m 0755 -d /etc/apt/keyrings
+            fi
+
             (wget -q -O- https://downloads.opennebula.io/repo/"${REPO_KEY}" |
                 gpg --dearmor --yes --output /etc/apt/keyrings/opennebula.gpg) || return 1
             echo "deb [signed-by=/etc/apt/keyrings/opennebula.gpg] ${REPO_BASE}/${DISTNAME}/${DISTVER} stable opennebula" \


### PR DESCRIPTION
Description:

This pull request enhances the configuration script for MiniOne repositories by adding a check and creation of the /etc/apt/keyrings directory on Debian systems. The modification ensures that the required directory is present before configuring repositories, preventing potential issues during the process.

In addition, this update aligns with the best practices demonstrated in the Docker installation example for Debian: [Docker Debian Installation Guide](https://docs.docker.com/engine/install/debian/).

Changes:

    Added a check for the existence of /etc/apt/keyrings on Debian systems.
    If the directory is not present, the script now creates it using install -m 0755 -d /etc/apt/keyrings.